### PR TITLE
Switch memcpy API to typed copy descriptors

### DIFF
--- a/trame-runtime/src/creusot_rt/mod.rs
+++ b/trame-runtime/src/creusot_rt/mod.rs
@@ -8,8 +8,8 @@ use creusot_std::model::DeepModel;
 use creusot_std::prelude::{View, logic, trusted};
 
 use crate::{
-    IArena, IField, IHeap, IPointerType, IPtr, IRuntime, IShape, IShapeExtra, IShapeStore,
-    IStructType, Idx,
+    CopyDesc, IArena, IField, IHeap, IPointerType, IPtr, IRuntime, IShape, IShapeExtra,
+    IShapeStore, IStructType, Idx,
 };
 
 /// Logical layout for creusot builds.
@@ -562,11 +562,12 @@ impl IHeap<CShapeView<'_>> for CHeap {
     }
 
     #[trusted]
-    #[cfg_attr(creusot, requires(self.range_init(src, _len)))]
-    #[cfg_attr(creusot, ensures(self.range_init(dst, _len)))]
+    #[cfg_attr(creusot, requires(self.range_init(src, desc.byte_len_logic())))]
+    #[cfg_attr(creusot, ensures(self.range_init(dst, desc.byte_len_logic())))]
     #[cfg_attr(creusot, ensures(forall<ptr2, shape2> ptr2 != dst ==> (^self).can_drop(ptr2, shape2) == (*self).can_drop(ptr2, shape2)))]
     #[cfg_attr(creusot, ensures(forall<ptr2, range2> ptr2 != dst ==> (^self).range_init(ptr2, range2) == (*self).range_init(ptr2, range2)))]
-    unsafe fn memcpy(&mut self, dst: CPtr, src: CPtr, _src_shape: CShapeView<'_>, _len: usize) {
+    unsafe fn memcpy(&mut self, dst: CPtr, src: CPtr, desc: CopyDesc<CShapeView<'_>>) {
+        let _ = desc;
         let _ = (dst, src);
     }
 

--- a/trame-runtime/src/live/mod.rs
+++ b/trame-runtime/src/live/mod.rs
@@ -1,7 +1,9 @@
 //! Live implementations of all of trame's runtime traits: no verification involved, real memory
 //! allocations, etc.
 
-use crate::{IArena, IField, IHeap, IPointerType, IRuntime, IShape, IShapeStore, IStructType, Idx};
+use crate::{
+    CopyDesc, IArena, IField, IHeap, IPointerType, IRuntime, IShape, IShapeStore, IStructType, Idx,
+};
 use facet_core::{
     Def, Field, KnownPointer, PointerDef, PtrMut, PtrUninit, Shape, StructType, Type, UserType,
 };
@@ -190,13 +192,8 @@ impl IHeap<&'static Shape> for LHeap {
         unsafe { self.dealloc(ptr, shape) };
     }
 
-    unsafe fn memcpy(
-        &mut self,
-        dst: *mut u8,
-        src: *mut u8,
-        _src_shape: &'static Shape,
-        len: usize,
-    ) {
+    unsafe fn memcpy(&mut self, dst: *mut u8, src: *mut u8, desc: CopyDesc<&'static Shape>) {
+        let len = desc.byte_len();
         if len > 0 {
             // SAFETY: caller guarantees non-overlapping, valid pointers
             unsafe {

--- a/trame-runtime/src/verified/mod.rs
+++ b/trame-runtime/src/verified/mod.rs
@@ -12,7 +12,8 @@ mod byte_range;
 use byte_range::{ByteRangeError, ByteRangeTracker, Range};
 
 use crate::{
-    IArena, IField, IHeap, IPointerType, IPtr, IRuntime, IShape, IShapeStore, IStructType, Idx,
+    CopyDesc, IArena, IField, IHeap, IPointerType, IPtr, IRuntime, IShape, IShapeStore,
+    IStructType, Idx,
 };
 
 /// A runtime that verifies all operations
@@ -1098,7 +1099,8 @@ impl<S: IShape> IHeap<S> for VHeap<S> {
         self.allocs[id as usize] = None;
     }
 
-    unsafe fn memcpy(&mut self, dst: VPtr, src: VPtr, _src_shape: S, len: usize) {
+    unsafe fn memcpy(&mut self, dst: VPtr, src: VPtr, desc: CopyDesc<S>) {
+        let len = desc.byte_len();
         if len == 0 {
             return;
         }


### PR DESCRIPTION
## Summary
- Replace `memcpy(dst, src, src_shape, len)` with a typed copy descriptor:
  - `CopyDesc::Value(shape)`
  - `CopyDesc::Repeat { elem, count }`
- Update `IHeap::memcpy` to take `CopyDesc<S>`.
- Thread the new API through all runtime implementations (`live`, `verified`, `creusot_rt`).
- Update Trame call sites to pass `CopyDesc::value(...)`.

## Why
A descriptor gives proofs and runtime checks a stronger semantic handle than raw byte length alone, while still supporting repeated-element copies without requiring synthetic slice shapes.

## Validation
- `cargo check`
