### PR TITLE
Add solver property tests with oracle cross-check

### DIFF
--- a/trame-proptest/Cargo.toml
+++ b/trame-proptest/Cargo.toml
@@ -8,8 +8,11 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+facet.workspace = true
+facet-core.workspace = true
 proptest.workspace = true
 trame = { path = "../trame" }
+trame-solver = { path = "../trame-solver" }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary
- add a dedicated `trame-solver` property-test harness in `trame-proptest`
- cover flatten-capable schema fixtures:
  - flattened struct
  - flattened optional struct
  - flattened enum field
- add a small oracle solver model for these tiny schemas and cross-check `solve_keys` outcomes against it
- assert solver invariants on successful resolutions:
  - each seen known key resolves to a route
  - `top_level_field_index` is in root-field bounds
  - `path_display` is non-empty and stable across repeated solves
- assert `NoMatch` invariants:
  - missing required fields are actually absent
  - detailed missing path strings are non-empty
  - unknown fields and missing-required sets match the oracle model

## Validation
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --all-features`
