### PR TITLE
Implement rope-backed stable staging for lists

### DIFF
--- a/trame-runtime/src/lib.rs
+++ b/trame-runtime/src/lib.rs
@@ -488,6 +488,27 @@ pub trait IHeap<S: IShape> {
     /// The caller must ensure `ptr` points to a live allocation for `shape`.
     unsafe fn dealloc_moved(&mut self, ptr: Self::Ptr, shape: S);
 
+    /// Allocate contiguous staging storage for `count` values of `elem_shape`.
+    ///
+    /// This is used by container rope staging to reserve stable chunk buffers.
+    ///
+    /// # Safety
+    /// The caller must ensure `elem_shape` is valid for allocation and `count`
+    /// is the intended number of elements for this chunk.
+    unsafe fn alloc_repeat(&mut self, elem_shape: S, count: usize) -> Self::Ptr;
+
+    /// Deallocate repeat storage previously allocated by `alloc_repeat`.
+    ///
+    /// # Safety
+    /// The caller must ensure all bytes in the chunk are uninitialized.
+    unsafe fn dealloc_repeat(&mut self, ptr: Self::Ptr, elem_shape: S, count: usize);
+
+    /// Deallocate repeat storage whose values were moved out without drop.
+    ///
+    /// # Safety
+    /// The caller must ensure `ptr` is a live allocation from `alloc_repeat`.
+    unsafe fn dealloc_repeat_moved(&mut self, ptr: Self::Ptr, elem_shape: S, count: usize);
+
     /// Copy bytes from `src` to `dst` according to a typed descriptor.
     ///
     /// # Safety


### PR DESCRIPTION
## Summary
Implement rope-backed stable staging for list construction in Trame.

## Changes
- Add repeat/chunk allocation hooks to `IHeap`:
  - `alloc_repeat`
  - `dealloc_repeat`
  - `dealloc_repeat_moved`
- Implement repeat allocation/deallocation in live runtime (`LHeap`).
- Implement verified parity in `VHeap` with explicit tracking for single vs repeat allocations.
- Switch list append staging to stable chunk buffers instead of per-element staged allocations.
- Keep close/finalize-time materialization into final list in one pass.
- Ensure cleanup/direct-overwrite paths correctly release staged chunk storage.
- Add tests for:
  - single-chunk behavior with capacity hint
  - multi-chunk growth behavior
  - verified runtime parity for chunk staging hints

## Test Plan
- `cargo nextest run`

Closes #36
