### PR TITLE
Add map last-wins regressions and VRuntime/fuzz map coverage

### DIFF
--- a/trame-fuzz/src/bin/vshape.rs
+++ b/trame-fuzz/src/bin/vshape.rs
@@ -15,6 +15,7 @@ pub enum FuzzScenario {
     Pointer,
     Option,
     List,
+    Map,
 }
 
 #[derive(Clone, Copy, Arbitrary)]
@@ -154,6 +155,23 @@ fn build_scenario_shape(scenario: FuzzScenario) -> VShapeView<'static, VShapeSto
                 VTypeOps::pod(),
             ));
             vshape_view(list)
+        }
+        FuzzScenario::Map => {
+            let key = vshape_register(VShapeDef::scalar_with_ops(
+                Layout::new::<usize>(),
+                VTypeOps::new(false, drop_noop, Some(default_magic)),
+            ));
+            let value = vshape_register(VShapeDef::scalar_with_ops(
+                Layout::new::<usize>(),
+                VTypeOps::new(false, drop_noop, Some(default_magic)),
+            ));
+            let map = vshape_register(VShapeDef::map_of(
+                key,
+                value,
+                Layout::new::<usize>(),
+                VTypeOps::pod(),
+            ));
+            vshape_view(map)
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR completes map follow-up work after #43 by covering both map materialization semantics and cross-layer map coverage.

It adds regression coverage for duplicate-key "last wins" behavior and cleanup paths in live runtime tests, then extends verified/runtime/fuzz/proptest layers so map shapes and map operation sequences are exercised beyond live execution.

## Changes
- Added map regressions in `trame` tests for:
  - strict-end duplicate-key materialization (`last wins`)
  - deferred-finalize duplicate-key materialization (`last wins`)
  - cleanup when overwriting staged map entries
  - cleanup on early error while map entry fields are partially complete
- Added verified runtime map modeling:
  - `VDef::Map` and `VMapDef`
  - `VShapeDef::map_of(...)`
  - `VShapeView::as_map()` + `VMapView` key/value metadata plumbing
- Added verified runtime tests for map metadata and matching-shape `map_insert_entry` behavior.
- Added `VRuntime` map path tests in `trame` for map append/end and deferred re-entry flows.
- Extended `trame-proptest` shape generation to include map recipes, plus a deterministic map append/deferred re-entry regression.
- Extended `trame-fuzz` VShape scenario set with a `Map` scenario.

## Test Plan
- `cargo fmt --all`
- `cargo nextest run -p trame-runtime`
- `cargo nextest run -p trame`
- `cargo nextest run -p trame-proptest`
- `cargo check -p trame-fuzz --bins`
- `cargo run -p trame-fuzz --bin vshape --features standalone < /dev/null`
- `cargo run -p trame-fuzz --bin trame-fuzz --features standalone < /dev/null`

Closes #40
Closes #41
